### PR TITLE
Fix retrieved database name for MySQL

### DIFF
--- a/lib/uff_db_loader/tasks/remote_database.rake
+++ b/lib/uff_db_loader/tasks/remote_database.rake
@@ -20,7 +20,7 @@ namespace :remote_database do
 
     puts "🤓 Reading from to #{result_file_path}"
 
-    database_name = File.basename(result_file_path).gsub(".dump", "")
+    database_name = File.basename(result_file_path, ".*")
     ActiveRecord::Base.connection.execute("CREATE DATABASE #{database_name};")
 
     puts "🗂  Created database #{database_name}"


### PR DESCRIPTION
MySQL dumps to *.sql files by default and our current code didn't know
about that and always assumed the *.dump. With this change, the
extension can be anything, as long as the filename itself is the
database name, we're fine.