### PR TITLE
Ensure valid enviroment is being picked from prompt

### DIFF
--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -54,6 +54,12 @@ module UffDbLoader
       .gsub("%target%", target)
   end
 
+  def self.ensure_valid_environment!(environment)
+    unless config.environments.include?(environment)
+      raise ForbiddenEnvironmentError, "Invalid environment: #{environment}."
+    end
+  end
+
   def self.restore_command(database_name, result_file_path)
     config.database_system.restore_command(database_name, result_file_path)
   end

--- a/lib/uff_db_loader/tasks/remote_database.rake
+++ b/lib/uff_db_loader/tasks/remote_database.rake
@@ -2,13 +2,12 @@
 
 require 'tty-prompt'
 
-raise ForbiddenEnvironmentError unless Rails.env.development?
-
 namespace :remote_database do
   desc "Dumps a remote database to #{UffDbLoader::DUMP_DIRECTORY}"
   task dump: :environment do
     prompt = TTY::Prompt.new
     environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
+    UffDbLoader.ensure_valid_environment!(environment)
     UffDbLoader.dump_from(environment)
   end
 
@@ -16,6 +15,7 @@ namespace :remote_database do
   task load: :environment do
     prompt = TTY::Prompt.new
     environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
+    UffDbLoader.ensure_valid_environment!(environment)
     result_file_path = UffDbLoader.dump_from(environment)
 
     puts "🤓 Reading from to #{result_file_path}"


### PR DESCRIPTION
This might be eagerly defensive, but I'd rather make sure we don't try to load
the wrong enviroment if somehow we manage to get the wrong environment
from the prompt

Successor of #5 