### PR TITLE
Remove duplicate environment check, since this is already checked in the tasks

### DIFF
--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -28,8 +28,6 @@ module UffDbLoader
   end
 
   def self.dump_from(environment)
-    raise "Invalid environment: #{environment}." unless config.environments.include?(environment)
-
     FileUtils.mkdir_p(DUMP_DIRECTORY)
 
     puts "⬇️  Creating dump ..."


### PR DESCRIPTION
See #8 