### PR TITLE
Rename task to uff_db_loader instead of remote_database

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure the app's database user has the superuser role. Otherwise the app will
 
 ## Usage
 
-`uff_db_loader` provides `rails remote_database:dump` and `rails remote_database:load` which will prompt for a configured environment.
+`uff_db_loader` provides `rails uff_db_loader:dump` and `rails uff_db_loader:load` which will prompt for a configured environment.
 `dump` will only create and download a current database dump, while `load`, will do the same and restore the database content into a new database and gives instructions on how to use it in development.
 
 

--- a/lib/uff_db_loader/tasks/remote_database.rake
+++ b/lib/uff_db_loader/tasks/remote_database.rake
@@ -5,44 +5,19 @@ require "tty-prompt"
 namespace :remote_database do
   desc "Dumps a remote database to #{UffDbLoader.config.dumps_directory}"
   task dump: :environment do
-    prompt = TTY::Prompt.new
-    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
-    UffDbLoader.ensure_valid_environment!(environment)
-    UffDbLoader.dump_from(environment)
+    puts "🧐 Please note this task is called 'uff_db_loader:dump' now."
+    Rake::Task["uff_db_loader:dump"].invoke
   end
 
   desc "Gets a dump from remote and loads it into the local database"
   task load: :environment do
-    prompt = TTY::Prompt.new
-    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
-    UffDbLoader.ensure_valid_environment!(environment)
-    result_file_path = UffDbLoader.dump_from(environment)
-
-    puts "🤓 Reading from to #{result_file_path}"
-
-    database_name = File.basename(result_file_path, ".*")
-    UffDbLoader.create_database(database_name)
-
-    puts "🗂  Created database #{database_name}"
-
-    command_successful = system(UffDbLoader.restore_command(database_name, result_file_path))
-    raise "Command did not run succesful: #{UffDbLoader.restore_command(database_name, result_file_path)}" unless command_successful
-
-    puts "✅ Succesfully loaded #{result_file_path} into #{database_name}"
-
-    puts "💩 Because YAML is a wonderful format, you need to adapt your config file by hand."
-    puts "🆗 Go to #{UffDbLoader.config.database_config_file} and change the development database value to: #{database_name}"
-    puts "🧑🏾‍🏫 Don't forgot to restart the Rails server after changing the database config (`rails restart`)"
+    puts "🧐 Please note this task is called 'uff_db_loader:load' now."
+    Rake::Task["uff_db_loader:load"].invoke
   end
 
   desc "Delete all downloaded db dumps and emove all databases created by UffDbLoader"
   task prune: :environment do
-    UffDbLoader.databases.each do |database_name|
-      puts "Dropping #{database_name}"
-      UffDbLoader.drop_database(database_name)
-    end
-
-    puts "Removing dumps from #{UffDbLoader.config.dumps_directory}"
-    UffDbLoader.prune_dump_directory
+    puts "🧐 Please note this task is called 'uff_db_loader:prune' now."
+    Rake::Task["uff_db_loader:prune"].invoke
   end
 end

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require "tty-prompt"
+
+namespace :uff_db_loader do
+  desc "Dumps a remote database to #{UffDbLoader.config.dumps_directory}"
+  task dump: :environment do
+    prompt = TTY::Prompt.new
+    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
+    UffDbLoader.ensure_valid_environment!(environment)
+    UffDbLoader.dump_from(environment)
+  end
+
+  desc "Gets a dump from remote and loads it into the local database"
+  task load: :environment do
+    prompt = TTY::Prompt.new
+    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments)
+    UffDbLoader.ensure_valid_environment!(environment)
+    result_file_path = UffDbLoader.dump_from(environment)
+
+    puts "🤓 Reading from to #{result_file_path}"
+
+    database_name = File.basename(result_file_path, ".*")
+    UffDbLoader.create_database(database_name)
+
+    puts "🗂  Created database #{database_name}"
+
+    command_successful = system(UffDbLoader.restore_command(database_name, result_file_path))
+    raise "Command did not run succesful: #{UffDbLoader.restore_command(database_name, result_file_path)}" unless command_successful
+
+    puts "✅ Succesfully loaded #{result_file_path} into #{database_name}"
+
+    puts "💩 Because YAML is a wonderful format, you need to adapt your config file by hand."
+    puts "🆗 Go to #{UffDbLoader.config.database_config_file} and change the development database value to: #{database_name}"
+    puts "🧑🏾‍🏫 Don't forgot to restart the Rails server after changing the database config (`rails restart`)"
+  end
+
+  desc "Delete all downloaded db dumps and emove all databases created by UffDbLoader"
+  task prune: :environment do
+    UffDbLoader.databases.each do |database_name|
+      puts "Dropping #{database_name}"
+      UffDbLoader.drop_database(database_name)
+    end
+
+    puts "Removing dumps from #{UffDbLoader.config.dumps_directory}"
+    UffDbLoader.prune_dump_directory
+  end
+end

--- a/lib/uff_db_loader/version.rb
+++ b/lib/uff_db_loader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UffDbLoader
-  VERSION = "1.1.1"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
We still keep the old name around for backwards compatibility, will
remove it with 2.0.