### PR TITLE
Improve first run experience further

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Run the installation script:
 You can configure the gem by running the following during the initialization of the Rails app:
 ```ruby
 UffDbLoader.configure do |config|
-  config.environments = ['sandbox', 'production'] # default is "['staging', 'production']"
+  config.environments = ['staging', 'production']
   config.ssh_user = 'Francina'
   config.ssh_host = 'host.of.yoursite'
   config.db_name = 'twotter'

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -8,7 +8,7 @@ module UffDbLoader
     attr_accessor :environments, :ssh_host, :ssh_user, :db_name, :db_system, :app_name, :dumps_directory, :database_config_file
 
     def initialize
-      @environments = %w[staging production]
+      @environments = nil
       @ssh_host = nil
       @ssh_user = nil
       @db_name = nil

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -144,6 +144,13 @@ module UffDbLoader
     puts "♻️  Restarted rails server with new database."
   end
 
+  def self.create_initializer
+    FileUtils.cp(
+      File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.rb"),
+      Rails.root.join("config", "initializers", "uff_db_loader.rb")
+    )
+  end
+
   class ForbiddenEnvironmentError < StandardError; end
 
   class UnknownDatabaseSystem < StandardError; end

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -156,6 +156,10 @@ module UffDbLoader
     end
   end
 
+  def self.environments
+    ActiveRecord::Base.configurations.configurations.to_a.map(&:env_name) - ["test", "development"]
+  end
+
   def self.create_initializer
     template = ERB.new(
       File.read(
@@ -165,7 +169,10 @@ module UffDbLoader
 
     File.write(
       Rails.root.join("config", "initializers", "uff_db_loader.rb"),
-      template.result_with_hash({used_database_system: used_database_system})
+      template.result_with_hash(
+        used_database_system: used_database_system,
+        environments: environments
+      )
     )
   end
 

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -145,9 +145,21 @@ module UffDbLoader
   end
 
   def self.create_initializer
-    FileUtils.cp(
-      File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.rb"),
-      Rails.root.join("config", "initializers", "uff_db_loader.rb")
+    used_database_system = case Rails.configuration.database_configuration["development"]["adapter"]
+    when "mysql", "mysql2", "trilogy"
+      ":mysql"
+    when "postgresql"
+      ":postgresql"
+    else
+      puts "🙃 Could not automatically determine your used database system. Please adapt in the initializer."
+      ":unknown"
+    end
+
+    template_contents = File.read(File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.rb"))
+
+    File.write(
+      Rails.root.join("config", "initializers", "uff_db_loader.rb"),
+      template_contents.gsub("%%DATABASE_SYSTEM%%", used_database_system)
     )
   end
 

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -105,7 +105,7 @@ module UffDbLoader
   def self.current_database_name
     File.read(database_name_file).strip.presence
   rescue IOError, Errno::ENOENT => e
-    puts "Could not read #{database_name_file}. #{e.message}"
+    puts "Could not read #{database_name_file}. #{e.message} – Falling back to default database. 🥱"
   end
 
   def self.remember_database_name(database_name)

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -160,12 +160,12 @@ module UffDbLoader
     ActiveRecord::Base.configurations.configurations.to_a.map(&:env_name) - ["test", "development"]
   end
 
+  def self.initializer_path
+    File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.erb")
+  end
+
   def self.create_initializer
-    template = ERB.new(
-      File.read(
-        File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.erb")
-      )
-    )
+    template = ERB.new(File.read(initializer_path))
 
     File.write(
       Rails.root.join("config", "initializers", "uff_db_loader.rb"),

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -155,11 +155,15 @@ module UffDbLoader
       ":unknown"
     end
 
-    template_contents = File.read(File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.rb"))
+    template = ERB.new(
+      File.read(
+        File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.erb")
+      )
+    )
 
     File.write(
       Rails.root.join("config", "initializers", "uff_db_loader.rb"),
-      template_contents.gsub("%%DATABASE_SYSTEM%%", used_database_system)
+      template.result_with_hash({used_database_system: used_database_system})
     )
   end
 

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -144,8 +144,8 @@ module UffDbLoader
     puts "♻️  Restarted rails server with new database."
   end
 
-  def self.create_initializer
-    used_database_system = case Rails.configuration.database_configuration["development"]["adapter"]
+  def self.used_database_system
+    case Rails.configuration.database_configuration["development"]["adapter"]
     when "mysql", "mysql2", "trilogy"
       ":mysql"
     when "postgresql"
@@ -154,7 +154,9 @@ module UffDbLoader
       puts "🙃 Could not automatically determine your used database system. Please adapt in the initializer."
       ":unknown"
     end
+  end
 
+  def self.create_initializer
     template = ERB.new(
       File.read(
         File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.erb")

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -7,6 +7,8 @@ namespace :uff_db_loader do
   task install: :environment do
     UffDbLoader.create_initializer
 
+    puts "👶 Created a Rails initializer file at #{UffDbLoader.initializer_path}."
+
     if UffDbLoader.setup_dynamic_database_name_in_config
       puts "🤖 Updated #{UffDbLoader.config.database_config_file}. Happy hacking, beep boop!"
     else

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -3,8 +3,12 @@
 require "tty-prompt"
 
 namespace :uff_db_loader do
-  desc "Set up #{UffDbLoader.config.database_config_file} to be used by uff_db_loader"
+  desc "Set up UffDbLoader"
   task install: :environment do
+    # create initializer
+
+    UffDbLoader.create_initializer
+
     if UffDbLoader.setup_dynamic_database_name_in_config
       puts "🤖 Updated #{UffDbLoader.config.database_config_file}. Happy hacking, beep boop!"
     else

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -5,8 +5,6 @@ require "tty-prompt"
 namespace :uff_db_loader do
   desc "Set up UffDbLoader"
   task install: :environment do
-    # create initializer
-
     UffDbLoader.create_initializer
 
     if UffDbLoader.setup_dynamic_database_name_in_config

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -5,8 +5,6 @@ require "tty-prompt"
 namespace :uff_db_loader do
   desc "Set up #{UffDbLoader.config.database_config_file} to be used by uff_db_loader"
   task install: :environment do
-    UffDbLoader.remember_database_name("") # ensure database file exists
-
     if UffDbLoader.setup_dynamic_database_name_in_config
       puts "🤖 Updated #{UffDbLoader.config.database_config_file}. Happy hacking, beep boop!"
     else

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -7,7 +7,7 @@ if defined?(UffDbLoader)
     config.ssh_user = 'SSH_USER'
     config.ssh_host = 'HOST_OF_YOUR_SITE'
     config.db_name = 'YOUR_DATABASE_NAME'
-    config.db_system = %%DATABASE_SYSTEM%% # Possible values are :postgresql and :mysql
+    config.db_system = <%= used_database_system %> # Possible values are :postgresql and :mysql
 
     # Optional settings:
     # config.environments = ['sandbox', 'production'] # default is "['staging', 'production']"

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -8,9 +8,9 @@ if defined?(UffDbLoader)
     config.ssh_host = 'HOST_OF_YOUR_SITE'
     config.db_name = 'YOUR_DATABASE_NAME'
     config.db_system = <%= used_database_system %> # Possible values are :postgresql and :mysql
+    config.environments = <%= environments %>
 
     # Optional settings:
-    # config.environments = ['sandbox', 'production'] # default is "['staging', 'production']"
     # config.app_name = 'my_app' # Defaults to the Rails app name
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.rb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# Check out our README: https://github.com/rmehner/uff_db_loader/blob/main/README.md
+
+if defined?(UffDbLoader)
+  UffDbLoader.configure do |config|
+    config.ssh_user = 'SSH_USER'
+    config.ssh_host = 'HOST_OF_YOUR_SITE'
+    config.db_name = 'YOUR_DATABASE_NAME'
+    config.db_system = :postgresql # Possible values are :postgresql and :mysql
+
+    # Optional settings:
+    # config.environments = ['sandbox', 'production'] # default is "['staging', 'production']"
+    # config.app_name = 'my_app' # Defaults to the Rails app name
+    # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
+    # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
+  end
+end

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.rb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.rb
@@ -7,7 +7,7 @@ if defined?(UffDbLoader)
     config.ssh_user = 'SSH_USER'
     config.ssh_host = 'HOST_OF_YOUR_SITE'
     config.db_name = 'YOUR_DATABASE_NAME'
-    config.db_system = :postgresql # Possible values are :postgresql and :mysql
+    config.db_system = %%DATABASE_SYSTEM%% # Possible values are :postgresql and :mysql
 
     # Optional settings:
     # config.environments = ['sandbox', 'production'] # default is "['staging', 'production']"


### PR DESCRIPTION
Closing #33 

- Improve error message when database name file not found (because it is expected to be not there in certain cases)
- Installer now also creates the initializer for you, including automatic detection of the database system