### PR TITLE
Configure container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ UffDbLoader.configure do |config|
   config.app_name = 'my_app' # Defaults to the Rails app name
   config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
   config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
+  config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db".
 end
 ```
 For example in a file like `config/initializers/uff_db_loader.rb`.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ UffDbLoader.configure do |config|
   config.app_name = 'my_app' # Defaults to the Rails app name
   config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
   config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
-  config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db".
+  config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db". It accepts a static string too.
 end
 ```
 For example in a file like `config/initializers/uff_db_loader.rb`.

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -14,7 +14,7 @@ module UffDbLoader
       :app_name,
       :dumps_directory,
       :database_config_file,
-      :container_name_fn
+      :container_name
     )
 
     def initialize
@@ -26,7 +26,7 @@ module UffDbLoader
       @app_name = Dir.pwd.split("/").last
       @dumps_directory = File.join(Dir.pwd, "dumps")
       @database_config_file = File.join(Dir.pwd, "config", "database.yml")
-      @container_name_fn = nil
+      @container_name = nil
     end
 
     def database

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -5,7 +5,17 @@ require "uff_db_loader/mysql"
 
 module UffDbLoader
   class Configuration
-    attr_accessor :environments, :ssh_host, :ssh_user, :db_name, :db_system, :app_name, :dumps_directory, :database_config_file
+    attr_accessor(
+      :environments,
+      :ssh_host,
+      :ssh_user,
+      :db_name,
+      :db_system,
+      :app_name,
+      :dumps_directory,
+      :database_config_file,
+      :container_name_fn
+    )
 
     def initialize
       @environments = nil
@@ -16,6 +26,7 @@ module UffDbLoader
       @app_name = Dir.pwd.split("/").last
       @dumps_directory = File.join(Dir.pwd, "dumps")
       @database_config_file = File.join(Dir.pwd, "config", "database.yml")
+      @container_name_fn = nil
     end
 
     def database

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -125,6 +125,12 @@ module UffDbLoader
 
     private
 
+    def container_name(environment)
+      return "#{config.app_name}_#{environment}_db" if config.container_name_fn.blank?
+
+      config.container_name_fn.call(config.app_name, environment)
+    end
+
     def initializer_template_path
       File.join(__dir__, "uff_db_loader", "templates", "uff_db_loader_initializer.erb")
     end
@@ -144,12 +150,11 @@ module UffDbLoader
       config
         .database_system
         .dump_command_template
-        .gsub("%environment%", environment)
         .gsub("%host%", config.ssh_host)
         .gsub("%user%", config.ssh_user)
         .gsub("%database%", config.database)
         .gsub("%target%", target)
-        .gsub("%app_name%", config.app_name)
+        .gsub("%container_name%", container_name(environment))
     end
 
     def restore_command(database_name, result_file_path)

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -126,9 +126,10 @@ module UffDbLoader
     private
 
     def container_name(environment)
-      return "#{config.app_name}_#{environment}_db" if config.container_name_fn.blank?
+      return "#{config.app_name}_#{environment}_db" if config.container_name.blank?
+      return config.container_name unless config.container_name.respond_to? :call
 
-      config.container_name_fn.call(config.app_name, environment)
+      config.container_name.call(config.app_name, environment)
     end
 
     def initializer_template_path

--- a/lib/uff_db_loader/mysql.rb
+++ b/lib/uff_db_loader/mysql.rb
@@ -7,7 +7,7 @@ module UffDbLoader
     end
 
     def self.dump_command_template
-      "ssh %user%@%host% \"docker exec -i %app_name%_%environment%_db sh -c 'exec mysqldump --opt --no-tablespaces -uroot -p\"\\$MYSQL_ROOT_PASSWORD\" %database%'\" > %target%"
+      "ssh %user%@%host% \"docker exec -i %container_name% sh -c 'exec mysqldump --opt --no-tablespaces -uroot -p\"\\$MYSQL_ROOT_PASSWORD\" %database%'\" > %target%"
     end
 
     def self.restore_command(database_name, result_file_path)

--- a/lib/uff_db_loader/postgresql.rb
+++ b/lib/uff_db_loader/postgresql.rb
@@ -7,7 +7,7 @@ module UffDbLoader
     end
 
     def self.dump_command_template
-      "ssh %user%@%host% \"docker exec -i %app_name%_%environment%_db sh -c 'exec pg_dump --username \\$POSTGRES_USER --clean --no-owner --no-acl --format=c %database%'\" > %target%"
+      "ssh %user%@%host% \"docker exec -i %container_name% sh -c 'exec pg_dump --username \\$POSTGRES_USER --clean --no-owner --no-acl --format=c %database%'\" > %target%"
     end
 
     def self.restore_command(database_name, result_file_path)

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -14,5 +14,6 @@ if defined?(UffDbLoader)
     # config.app_name = 'my_app' # Defaults to the Rails app name
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
+    # config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db".
   end
 end

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -14,6 +14,6 @@ if defined?(UffDbLoader)
     # config.app_name = 'my_app' # Defaults to the Rails app name
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
-    # config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db".
+    # config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db". It accepts a static string too.
   end
 end

--- a/spec/uff_db_loader_spec.rb
+++ b/spec/uff_db_loader_spec.rb
@@ -2,4 +2,14 @@ RSpec.describe UffDbLoader do
   it "has a version number" do
     expect(UffDbLoader::VERSION).not_to be nil
   end
+
+  describe "configure" do
+    it "allows to set a container_name dynamically" do
+      UffDbLoader.configure do |config|
+        config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_db_v15" }
+      end
+
+      expect(UffDbLoader.send(:container_name, "sandbox")).to eq "uff_db_loader_sandbox_db_v15"
+    end
+  end
 end

--- a/spec/uff_db_loader_spec.rb
+++ b/spec/uff_db_loader_spec.rb
@@ -6,10 +6,18 @@ RSpec.describe UffDbLoader do
   describe "configure" do
     it "allows to set a container_name dynamically" do
       UffDbLoader.configure do |config|
-        config.container_name_fn = ->(app_name, environment) { "#{app_name}_#{environment}_db_v15" }
+        config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_db_v15" }
       end
 
       expect(UffDbLoader.send(:container_name, "sandbox")).to eq "uff_db_loader_sandbox_db_v15"
+    end
+
+    it "allows to set a container_name statically" do
+      UffDbLoader.configure do |config|
+        config.container_name = "uff_db_loader_db_v15"
+      end
+
+      expect(UffDbLoader.send(:container_name, "sandbox")).to eq "uff_db_loader_db_v15"
     end
   end
 end


### PR DESCRIPTION
I'd like to avoid the `send` in `UffDbLoader.send(:container_name, "sandbox")`, but I think that would require an architecture change. Currently the public interface of `UffDbLoader` is calling a method to execute a call to `system`, which I could test and using `Kernel.system` explicitly instead of just `system`, but this feels a bit clunky and the `puts`-output was still visible:
```ruby
expect(Kernel).to receive(:system) do |*, last_cmd|
  expect(last_cmd).to match(/uff_db_loader_sandbox_db_v15/)
end
```

I think to get the tests to feel right we should use something like [the command pattern](https://refactoring.guru/design-patterns/command/ruby/example), but I think that's out of scope for this PR.