### PR TITLE
Allows to set a path to your local db cli tools

### DIFF
--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -15,7 +15,7 @@ module UffDbLoader
       :dumps_directory,
       :database_config_file,
       :container_name,
-      :local_cli_path
+      :local_restore_command_path
     )
 
     def initialize
@@ -28,7 +28,7 @@ module UffDbLoader
       @dumps_directory = File.join(Dir.pwd, "dumps")
       @database_config_file = File.join(Dir.pwd, "config", "database.yml")
       @container_name = nil
-      @local_cli_path = nil
+      @local_restore_command_path = nil
     end
 
     def database

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -15,8 +15,7 @@ module UffDbLoader
       :dumps_directory,
       :database_config_file,
       :container_name,
-      :local_mysql_cli_path,
-      :local_psql_cli_path
+      :local_cli_path
     )
 
     def initialize
@@ -29,8 +28,7 @@ module UffDbLoader
       @dumps_directory = File.join(Dir.pwd, "dumps")
       @database_config_file = File.join(Dir.pwd, "config", "database.yml")
       @container_name = nil
-      @local_mysql_cli_path = nil
-      @local_psql_cli_path = nil
+      @local_cli_path = nil
     end
 
     def database

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -14,7 +14,9 @@ module UffDbLoader
       :app_name,
       :dumps_directory,
       :database_config_file,
-      :container_name
+      :container_name,
+      :local_mysql_cli_path,
+      :local_psql_cli_path
     )
 
     def initialize
@@ -27,6 +29,8 @@ module UffDbLoader
       @dumps_directory = File.join(Dir.pwd, "dumps")
       @database_config_file = File.join(Dir.pwd, "config", "database.yml")
       @container_name = nil
+      @local_mysql_cli_path = nil
+      @local_psql_cli_path = nil
     end
 
     def database

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -177,7 +177,7 @@ module UffDbLoader
     end
 
     def restore_command(database_name, result_file_path)
-      config.database_system.restore_command(database_name, result_file_path)
+      config.database_system.restore_command(database_name, result_file_path, config)
     end
 
     def database_name_template(old_database_name)

--- a/lib/uff_db_loader/mysql.rb
+++ b/lib/uff_db_loader/mysql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join([config.local_mysql_cli_path, "mysql"].compact)} -uroot #{database_name} < #{result_file_path}"
+      "#{File.join([config.local_cli_path, "mysql"].compact)} -uroot #{database_name} < #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/mysql.rb
+++ b/lib/uff_db_loader/mysql.rb
@@ -10,8 +10,8 @@ module UffDbLoader
       "ssh %user%@%host% \"docker exec -i %container_name% sh -c 'exec mysqldump --opt --single-transaction --routines --triggers --events --no-tablespaces -uroot -p\"\\$MYSQL_ROOT_PASSWORD\" %database%'\" > %target%"
     end
 
-    def self.restore_command(database_name, result_file_path)
-      "mysql -uroot #{database_name} < #{result_file_path}"
+    def self.restore_command(database_name, result_file_path, config)
+      "#{File.join([config.local_mysql_cli_path, "mysql"].compact)} -uroot #{database_name} < #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/mysql.rb
+++ b/lib/uff_db_loader/mysql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join([config.local_cli_path, "mysql"].compact)} -uroot #{database_name} < #{result_file_path}"
+      "#{File.join(config.local_cli_path || "mysql")} -uroot #{database_name} < #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/mysql.rb
+++ b/lib/uff_db_loader/mysql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join(config.local_cli_path || "mysql")} -uroot #{database_name} < #{result_file_path}"
+      "#{File.join(config.local_restore_command_path || "mysql")} -uroot #{database_name} < #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/postgresql.rb
+++ b/lib/uff_db_loader/postgresql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join(config.local_cli_path || "pg_restore")} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
+      "#{File.join(config.local_restore_command_path || "pg_restore")} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/postgresql.rb
+++ b/lib/uff_db_loader/postgresql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join([config.local_psql_cli_path, "pg_restore"].compact)} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
+      "#{File.join([config.local_cli_path, "pg_restore"].compact)} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/postgresql.rb
+++ b/lib/uff_db_loader/postgresql.rb
@@ -11,7 +11,7 @@ module UffDbLoader
     end
 
     def self.restore_command(database_name, result_file_path, config)
-      "#{File.join([config.local_cli_path, "pg_restore"].compact)} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
+      "#{File.join(config.local_cli_path || "pg_restore")} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/postgresql.rb
+++ b/lib/uff_db_loader/postgresql.rb
@@ -10,8 +10,8 @@ module UffDbLoader
       "ssh %user%@%host% \"docker exec -i %container_name% sh -c 'exec pg_dump --username \\$POSTGRES_USER --clean --no-owner --no-acl --format=c %database%'\" > %target%"
     end
 
-    def self.restore_command(database_name, result_file_path)
-      "pg_restore --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
+    def self.restore_command(database_name, result_file_path, config)
+      "#{File.join([config.local_psql_cli_path, "pg_restore"].compact)} --username postgres --clean --if-exists --no-owner --no-acl --dbname #{database_name} #{result_file_path}"
     end
 
     def self.list_databases

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -15,5 +15,7 @@ if defined?(UffDbLoader)
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
     # config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db". It accepts a static string too.
+    # config.local_mysql_cli_path = '' # Defaults to nil. So it uses what is configured in $PATH.
+    # config.local_psql_cli_path = '' # Defaults to nil. So it uses what is configured in $PATH.
   end
 end

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -15,6 +15,6 @@ if defined?(UffDbLoader)
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
     # config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db". It accepts a static string too.
-    # config.local_cli_path = '' # Sets the path to the db-cli (psql, mysql). Defaults to nil so it uses what is configured in $PATH.
+    # config.local_restore_command_path = '' # Sets the path to the db-cli (pg_restore, mysql). Defaults to nil so it uses what is configured in $PATH.
   end
 end

--- a/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
+++ b/lib/uff_db_loader/templates/uff_db_loader_initializer.erb
@@ -15,7 +15,6 @@ if defined?(UffDbLoader)
     # config.dumps_directory = '/path/to/dumps' # Defaults to Rails.root.join('dumps')
     # config.database_config_file = 'path/to/database.yml' # Defaults to Rails.root.join('config', 'database.yml')
     # config.container_name = ->(app_name, environment) { "#{app_name}_#{environment}_custom_suffix" } # Defaults to "#{app_name}_#{environment}_db". It accepts a static string too.
-    # config.local_mysql_cli_path = '' # Defaults to nil. So it uses what is configured in $PATH.
-    # config.local_psql_cli_path = '' # Defaults to nil. So it uses what is configured in $PATH.
+    # config.local_cli_path = '' # Sets the path to the db-cli (psql, mysql). Defaults to nil so it uses what is configured in $PATH.
   end
 end


### PR DESCRIPTION
So you can configure a fitting psql/mysql version to be used for restoring dumps. This addresses an error I encountered in one of our projects while using `pg_restore`: "unrecognized configuration parameter".

Postgres.app encourages us to always use the latest psql version:

https://postgresapp.com/documentation/cli-tools.html

and does not allow to easily switch to a different `psql`-version. The only way I found was changing $PATH manually, which is cumbersome. Postgres versioning tools usually change the postgres-server version (as well) leading to potential unexpected behaviour in combination with Postgress.app.