### PR TITLE
Allow to set prune days

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Make sure the app's database user has the superuser role. Otherwise the app will
 - `switch`: Selects a restored local database to use
 - `switch_to_default`: Switches database back to the default development database
 - `load`: Dumps a remote database from a selected environment and downloads it then restores and selects the database
-- `prune`: Delete all downloaded db dumps and removes all databases created by UffDbLoader
+- `prune`: Delete all downloaded db dumps and removes all databases created by UffDbLoader. Pass a number of days to only prune dumps and databases older than that, e.g. `bin/rails "uff_db_loader:prune[7]"` prunes everything older than 7 days
 - `current`: Shows the currently connected database and the one UffDbLoader has selected
 
 ## Development

--- a/lib/uff_db_loader.rb
+++ b/lib/uff_db_loader.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "time"
 require "uff_db_loader/version"
 require "configuration"
 
@@ -68,10 +69,18 @@ module UffDbLoader
       end
     end
 
-    def prune_dump_directory
-      FileUtils.rm_f(
-        FileList["#{config.dumps_directory}/*"].exclude(dump_file_path(current_database_name)).to_a
-      )
+    def prune_dump_directory(max_age = nil)
+      files = FileList["#{config.dumps_directory}/*"].exclude(dump_file_path(current_database_name)).to_a
+      files = files.select { |file| older_than?(File.basename(file, ".*"), max_age) } if max_age
+
+      FileUtils.rm_f(files)
+    end
+
+    def older_than?(name, max_age)
+      timestamp = name.to_s[-TIMESTAMP_LENGTH..]
+      Time.strptime(timestamp, TIMESTAMP_FORMAT) < (Time.now - max_age)
+    rescue ArgumentError, TypeError
+      false
     end
 
     def create_database(database_name)

--- a/lib/uff_db_loader/tasks/uff_db_loader.rake
+++ b/lib/uff_db_loader/tasks/uff_db_loader.rake
@@ -20,7 +20,8 @@ namespace :uff_db_loader do
   desc "Dumps a remote database from a selected environment to #{UffDbLoader.config.dumps_directory}"
   task dump: :environment do
     prompt = TTY::Prompt.new
-    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments, filter: true)
+    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments,
+      filter: true)
     UffDbLoader.ensure_valid_environment!(environment)
     UffDbLoader.dump_from(environment)
   end
@@ -57,7 +58,8 @@ namespace :uff_db_loader do
     UffDbLoader.connect_to_default_database
 
     prompt = TTY::Prompt.new
-    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments, filter: true)
+    environment = prompt.select("Which environment should we get the dump from?", UffDbLoader.config.environments,
+      filter: true)
     UffDbLoader.ensure_valid_environment!(environment)
     result_file_path = UffDbLoader.dump_from(environment)
 
@@ -67,17 +69,20 @@ namespace :uff_db_loader do
     UffDbLoader.load_dump_into_database(database_name)
   end
 
-  desc "Delete all downloaded db dumps and removes all databases created by UffDbLoader"
-  task prune: :environment do
+  desc "Delete downloaded db dumps and databases created by UffDbLoader. Pass a number of days (e.g. prune[7]) to only prune those older than that."
+  task :prune, [:older_than_days] => :environment do |_task, args|
+    max_age = args[:older_than_days] && (args[:older_than_days].to_i * 24 * 60 * 60)
+
     UffDbLoader.databases.each do |database_name|
       next if database_name == ActiveRecord::Base.connection.current_database
+      next if max_age && !UffDbLoader.older_than?(database_name, max_age)
 
       UffDbLoader.log "Dropping #{database_name}"
       UffDbLoader.drop_database(database_name)
     end
 
     UffDbLoader.log "Removing dumps from #{UffDbLoader.config.dumps_directory}"
-    UffDbLoader.prune_dump_directory
+    UffDbLoader.prune_dump_directory(max_age)
   end
 
   desc "Switch back to default database"
@@ -94,8 +99,6 @@ namespace :uff_db_loader do
     selected_database = UffDbLoader.current_database_name
 
     UffDbLoader.log "Active Record connected to: #{ActiveRecord::Base.connection.current_database}"
-    unless selected_database.nil?
-      UffDbLoader.log "Selected database: #{selected_database}"
-    end
+    UffDbLoader.log "Selected database: #{selected_database}" unless selected_database.nil?
   end
 end

--- a/lib/uff_db_loader/version.rb
+++ b/lib/uff_db_loader/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module UffDbLoader
-  VERSION = "4.1.1"
+  VERSION = "4.2.0"
 end

--- a/spec/rake_tasks_spec.rb
+++ b/spec/rake_tasks_spec.rb
@@ -78,4 +78,54 @@ RSpec.describe "rake tasks" do
       expect(UffDbLoader).not_to have_received(:dump_from)
     end
   end
+
+  describe "uff_db_loader:prune" do
+    let(:old_database) { "uff_db_loader_staging_#{(Time.now - (10 * 24 * 60 * 60)).strftime(UffDbLoader::TIMESTAMP_FORMAT)}" }
+    let(:fresh_database) { "uff_db_loader_staging_#{Time.now.strftime(UffDbLoader::TIMESTAMP_FORMAT)}" }
+
+    around do |example|
+      original_application = Rake.application
+
+      Rake.application = Rake::Application.new
+      Rake::Task.define_task(:environment)
+      load File.expand_path("../lib/uff_db_loader/tasks/uff_db_loader.rake", __dir__)
+
+      example.run
+    ensure
+      Rake.application = original_application
+    end
+
+    before do
+      UffDbLoader.reset
+      allow(UffDbLoader).to receive(:log)
+      allow(UffDbLoader).to receive(:prune_dump_directory)
+      allow(UffDbLoader).to receive(:drop_database)
+      allow(UffDbLoader).to receive(:databases).and_return([old_database, fresh_database])
+      allow(ActiveRecord::Base).to receive_message_chain(:connection, :current_database).and_return("uff_db_loader_development")
+    end
+
+    it "drops every database when invoked without an age" do
+      Rake::Task["uff_db_loader:prune"].invoke
+
+      expect(UffDbLoader).to have_received(:drop_database).with(old_database)
+      expect(UffDbLoader).to have_received(:drop_database).with(fresh_database)
+      expect(UffDbLoader).to have_received(:prune_dump_directory).with(nil)
+    end
+
+    it "only drops databases older than the given number of days" do
+      Rake::Task["uff_db_loader:prune"].invoke("7")
+
+      expect(UffDbLoader).to have_received(:drop_database).with(old_database)
+      expect(UffDbLoader).not_to have_received(:drop_database).with(fresh_database)
+      expect(UffDbLoader).to have_received(:prune_dump_directory).with(7 * 24 * 60 * 60)
+    end
+
+    it "never drops the currently connected database" do
+      allow(UffDbLoader).to receive(:databases).and_return(["uff_db_loader_development", old_database])
+
+      Rake::Task["uff_db_loader:prune"].invoke
+
+      expect(UffDbLoader).not_to have_received(:drop_database).with("uff_db_loader_development")
+    end
+  end
 end

--- a/spec/uff_db_loader_spec.rb
+++ b/spec/uff_db_loader_spec.rb
@@ -78,4 +78,23 @@ RSpec.describe UffDbLoader do
       expect(UffDbLoader.send(:database_name, "sandbox")).to eq "deploy-user"
     end
   end
+
+  describe "older_than?" do
+    let(:a_day) { 24 * 60 * 60 }
+    let(:seven_days) { 7 * a_day }
+    let(:old_name) { "uff_db_loader_staging_#{(Time.now - 10 * a_day).strftime(UffDbLoader::TIMESTAMP_FORMAT)}" }
+    let(:fresh_name) { "uff_db_loader_staging_#{Time.now.strftime(UffDbLoader::TIMESTAMP_FORMAT)}" }
+
+    it "is true when the embedded timestamp is older than the max age" do
+      expect(UffDbLoader.older_than?(old_name, seven_days)).to be true
+    end
+
+    it "is false when the embedded timestamp is within the max age" do
+      expect(UffDbLoader.older_than?(fresh_name, seven_days)).to be false
+    end
+
+    it "is false when the name has no parseable timestamp" do
+      expect(UffDbLoader.older_than?("some_manually_created_database", seven_days)).to be false
+    end
+  end
 end


### PR DESCRIPTION
By default, rake uff_db_loader:prune will delete all databases, but the
currrent one. With the argument, you can tell it to only delete
databases older than N days.